### PR TITLE
提供 头像右下角 Emoji 可自定义的能力

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -70,7 +70,7 @@ spec:
         - $formkit: text
           name: profileEmoji
           label: 状态Emoji
-          value: "🍥✍️"
+          value: "🍥"
         - $formkit: attachment
           name: profileAvatar
           label: 头像

--- a/settings.yaml
+++ b/settings.yaml
@@ -66,7 +66,11 @@ spec:
         - $formkit: text
           name: profileDesc
           label: 描述信息
-          value: "无限进步.✍️"
+          value: "无限进步.✍️"  
+        - $formkit: text
+          name: profileEmoji
+          label: 状态Emoji
+          value: "🍥✍️"
         - $formkit: attachment
           name: profileAvatar
           label: 头像

--- a/templates/modules/left-sidebar.html
+++ b/templates/modules/left-sidebar.html
@@ -13,7 +13,8 @@
                      width=300 height=300 class=site-logo loading=lazy alt=Avatar>
             </a>
             <span class=emoji>
-              🍥
+                [[${theme.config.leftSidebar.profileEmoji ?: 🍥}]]
+              
             </span>
         </figure>
         <div class=site-meta>

--- a/templates/modules/left-sidebar.html
+++ b/templates/modules/left-sidebar.html
@@ -13,8 +13,7 @@
                      width=300 height=300 class=site-logo loading=lazy alt=Avatar>
             </a>
             <span class=emoji>
-                [[${theme.config.leftSidebar.profileEmoji ?: 🍥}]]
-              
+                [[${theme.config.leftSidebar.profileEmoji}]]
             </span>
         </figure>
         <div class=site-meta>


### PR DESCRIPTION
允许用户在 主题设置 -> 左边栏 自定义 emoji

![screenshot-20230927-114318](https://github.com/jiewenhuang/halo-theme-stack/assets/39891083/4d0a62af-3be8-48f9-87ec-aa2d18e05d22)
