### PR TITLE
修复图库页面标题路由错误

### DIFF
--- a/templates/photos.html
+++ b/templates/photos.html
@@ -12,7 +12,7 @@
                     <div class="article-details">
                         <div class="article-title-wrapper">
                             <h2 class="article-title">
-                                <a href="index.html"
+                                <a href="/photos"
                                    th:if="${! #strings.isEmpty(theme.config.photos.title)}"
                                    th:text="${theme.config.photos.title}"></a>
                             </h2>


### PR DESCRIPTION
相册标题路由默认为`/index.html`，在个人网站中如果没有此页面设置的话会导致404。

提议修改：按照别的页面标题默认路由到自身