### PR TITLE
修复相册页面标题路由错误

### DIFF
--- a/templates/photos.html
+++ b/templates/photos.html
@@ -12,7 +12,7 @@
                     <div class="article-details">
                         <div class="article-title-wrapper">
                             <h2 class="article-title">
-                                <a href="index.html"
+                                <a href="photos"
                                    th:if="${! #strings.isEmpty(theme.config.photos.title)}"
                                    th:text="${theme.config.photos.title}"></a>
                             </h2>


### PR DESCRIPTION
相册页面标题默认路由到`/index.html`，如果网站没有此页面会导致404。
建议修改：默认路由到页面本身，即`/photos`